### PR TITLE
ksud: Bring back legacy temporary dir (/sbin)

### DIFF
--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -25,6 +25,7 @@ pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 pub const KSUD_VERBOSE_LOG_FILE: &str = concatcp!(ADB_DIR, "verbose");
 
 pub const TEMP_DIR: &str = "/debug_ramdisk";
+pub const TEMP_DIR_LEGACY: &str = "/sbin";
 
 pub const MODULE_WEB_DIR: &str = "webroot";
 pub const MODULE_ACTION_SH: &str = "action.sh";
@@ -32,7 +33,12 @@ pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";
 pub const REMOVE_FILE_NAME: &str = "remove";
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
-pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, "/workdir");
+
+// this shouldn't public
+const MAGIC_MOUNT_WORKDIR_FOLDER: &str = "/workdir";
+
+pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, MAGIC_MOUNT_WORKDIR_FOLDER);
+pub const MAGIC_MOUNT_WORK_DIR_LEGACY: &str = concatcp!(TEMP_DIR_LEGACY, MAGIC_MOUNT_WORKDIR_FOLDER);
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,41 +1,24 @@
-use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR};
+use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR, TEMP_DIR_LEGACY};
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};
 use log::{info, warn};
-use rustix::{fd::AsFd, fs::CWD, fs::MountFlags, mount::*};
+use rustix::{fs::MountFlags, mount::*};
 use std::path::Path;
 
 // https://github.com/tiann/KernelSU/blob/v0.9.5/userspace/ksud/src/mount.rs#L158
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn mount_tmpfs(dest: impl AsRef<Path>) -> Result<()> {
-    info!("mount tmpfs on {}", dest.as_ref().display());
-    if let Result::Ok(fs) = fsopen("tmpfs", FsOpenFlags::FSOPEN_CLOEXEC) {
-        let fs = fs.as_fd();
-        fsconfig_set_string(fs, "source", KSU_MOUNT_SOURCE)?;
-        fsconfig_create(fs)?;
-        let mount = fsmount(fs, FsMountFlags::FSMOUNT_CLOEXEC, MountAttrFlags::empty())?;
-        move_mount(
-            mount.as_fd(),
-            "",
-            CWD,
-            dest.as_ref(),
-            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
-        )?;
+fn mount_tmpfs() -> Result<()> {
+    if utils::legacy_tempdir_ok() {
+        mount(KSU_MOUNT_SOURCE, defs::TEMP_DIR_LEGACY, "tmpfs", MountFlags::empty(), "")?;
     } else {
-        mount(
-            KSU_MOUNT_SOURCE,
-            dest.as_ref(),
-            "tmpfs",
-            MountFlags::empty(),
-            "",
-        )?;
+        mount(KSU_MOUNT_SOURCE, defs::TEMP_DIR, "tmpfs", MountFlags::empty(), "")?;
     }
     Ok(())
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn mount_tmpfs(dest: impl AsRef<Path>) -> Result<()> {
+fn mount_tmpfs() -> Result<()> {
     unimplemented!()
 }
 
@@ -102,7 +85,7 @@ pub fn on_post_data_fs() -> Result<()> {
 
     // mount temp dir
     if !Path::new(NO_TMPFS_PATH).exists() {
-        if let Err(e) = mount_tmpfs(TEMP_DIR) {
+        if let Err(e) = mount_tmpfs() {
             warn!("do temp dir mount failed: {}", e);
         }
     } else {

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,4 +1,4 @@
-use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR, TEMP_DIR_LEGACY};
+use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH};
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -425,7 +425,7 @@ pub fn magic_mount() -> Result<()> {
             tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
         }
         ensure_dir_exists(&tmp_dir)?;
-        log::info!("magic mount workdir path: {}", tmp_dir);
+        log::info!("magic mount workdir path: {}", &tmp_dir);
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;
         let result = do_magic_mount("/", &tmp_dir, root, false);

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -425,7 +425,7 @@ pub fn magic_mount() -> Result<()> {
             tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
         }
         ensure_dir_exists(&tmp_dir)?;
-        log::info!("magic mount workdir path: {}", &tmp_dir);
+        log::info!("magic mount workdir path: {:#?}", tmp_dir.to_string_lossy());
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;
         let result = do_magic_mount("/", &tmp_dir, root, false);

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -425,7 +425,6 @@ pub fn magic_mount() -> Result<()> {
             tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
         }
         ensure_dir_exists(&tmp_dir)?;
-        log::info!("magic mount workdir path: {:#?}", tmp_dir.to_string_lossy());
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;
         let result = do_magic_mount("/", &tmp_dir, root, false);

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -1,9 +1,10 @@
 use crate::defs::{
-    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MAGIC_MOUNT_WORK_DIR, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
+    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MAGIC_MOUNT_WORK_DIR, 
+    MAGIC_MOUNT_WORK_DIR_LEGACY, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
 };
 use crate::magic_mount::NodeFileType::{Directory, RegularFile, Symlink, Whiteout};
 use crate::restorecon::{lgetfilecon, lsetfilecon};
-use crate::utils::ensure_dir_exists;
+use crate::utils::{ensure_dir_exists, legacy_tempdir_ok};
 use anyhow::{bail, Context, Result};
 use extattr::lgetxattr;
 use rustix::fs::{
@@ -417,8 +418,14 @@ fn do_magic_mount<P: AsRef<Path>, WP: AsRef<Path>>(
 pub fn magic_mount() -> Result<()> {
     if let Some(root) = collect_module_files()? {
         log::debug!("collected: {:#?}", root);
-        let tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
+        let tmp_dir;
+        if legacy_tempdir_ok() {
+            tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR_LEGACY);
+        } else {
+            tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
+        }
         ensure_dir_exists(&tmp_dir)?;
+        log::info!("magic mount workdir path: {}", tmp_dir);
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;
         let result = do_magic_mount("/", &tmp_dir, root, false);

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -177,6 +177,16 @@ pub fn has_magisk() -> bool {
     which::which("magisk").is_ok()
 }
 
+pub fn legacy_tempdir_ok() -> bool {
+    if std::fs::metadata(defs::TEMP_DIR_LEGACY).is_ok() {
+        log::info!("temp dir: {}", defs::TEMP_DIR_LEGACY);
+        return true;
+    } else {
+        log::info!("temp dir: {}", defs::TEMP_DIR);
+        return false;
+    }
+}
+
 #[cfg(target_os = "android")]
 fn link_ksud_to_bin() -> Result<()> {
     let ksu_bin = PathBuf::from(defs::DAEMON_PATH);


### PR DESCRIPTION
In this commit https://github.com/tiann/KernelSU/commit/fd09ccfc2906ad119f7158f9518810e06a73a919 TEMP_DIR_LEGACY was removed, so i restore it back.

We only use /debug_ramdisk and /sbin because of this https://github.com/tiann/KernelSU/commit/71cb86c2e9a9e1e9c323cf06dd287e8a69616904#commitcomment-143172576