### PR TITLE
ksud: Bring back /sbin as TEMP_DIR_LEGACY

### DIFF
--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -25,6 +25,7 @@ pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 pub const KSUD_VERBOSE_LOG_FILE: &str = concatcp!(ADB_DIR, "verbose");
 
 pub const TEMP_DIR: &str = "/debug_ramdisk";
+pub const TEMP_DIR_LEGACY: &str = "/sbin";
 
 pub const MODULE_WEB_DIR: &str = "webroot";
 pub const MODULE_ACTION_SH: &str = "action.sh";
@@ -32,7 +33,6 @@ pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";
 pub const REMOVE_FILE_NAME: &str = "remove";
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
-pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, "/workdir");
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,4 +1,4 @@
-use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR};
+use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH};
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};
@@ -102,7 +102,7 @@ pub fn on_post_data_fs() -> Result<()> {
 
     // mount temp dir
     if !Path::new(NO_TMPFS_PATH).exists() {
-        if let Err(e) = mount_tmpfs(TEMP_DIR) {
+        if let Err(e) = mount_tmpfs(utils::get_tmp_path()) {
             warn!("do temp dir mount failed: {}", e);
         }
     } else {

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -1,9 +1,9 @@
 use crate::defs::{
-    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MAGIC_MOUNT_WORK_DIR, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
+    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
 };
 use crate::magic_mount::NodeFileType::{Directory, RegularFile, Symlink, Whiteout};
 use crate::restorecon::{lgetfilecon, lsetfilecon};
-use crate::utils::ensure_dir_exists;
+use crate::utils::{ensure_dir_exists, get_work_dir};
 use anyhow::{bail, Context, Result};
 use extattr::lgetxattr;
 use rustix::fs::{
@@ -417,7 +417,7 @@ fn do_magic_mount<P: AsRef<Path>, WP: AsRef<Path>>(
 pub fn magic_mount() -> Result<()> {
     if let Some(root) = collect_module_files()? {
         log::debug!("collected: {:#?}", root);
-        let tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
+        let tmp_dir = PathBuf::from(get_work_dir());
         ensure_dir_exists(&tmp_dir)?;
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::{assets, boot_patch, defs, ksucalls, module, restorecon};
+use std::fs::metadata;
 #[allow(unused_imports)]
 use std::fs::{set_permissions, Permissions};
 #[cfg(unix)]
@@ -175,6 +176,21 @@ pub fn umask(_mask: u32) {
 
 pub fn has_magisk() -> bool {
     which::which("magisk").is_ok()
+}
+
+pub fn get_tmp_path() -> &'static str {
+    if metadata(defs::TEMP_DIR_LEGACY).is_ok() {
+        return defs::TEMP_DIR_LEGACY;
+    }
+    if metadata(defs::TEMP_DIR).is_ok() {
+        return defs::TEMP_DIR;
+    }
+    ""
+}
+
+pub fn get_work_dir() -> String {
+    let tmp_path = get_tmp_path();
+    format!("{}/workdir/", tmp_path)
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
In this commit https://github.com/tiann/KernelSU/commit/fd09ccfc2906ad119f7158f9518810e06a73a919 TEMP_DIR_LEGACY was removed, so i restore it back.

We only use /debug_ramdisk and /sbin because of this https://github.com/tiann/KernelSU/commit/71cb86c2e9a9e1e9c323cf06dd287e8a69616904#commitcomment-143172576

Cherry-picks from:
- https://github.com/bmax121/APatch/blob/main/apd/src/utils.rs
- https://github.com/bmax121/APatch/blob/main/apd/src/m_mount.rs

Notice: You may experiencing some issue with module, please backup your modules before preceeding