### PR TITLE
core_hook.c: Fix typo

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -60,7 +60,7 @@ bool susfs_is_allow_su(void)
 }
 
 extern u32 susfs_zygote_sid;
-+extern bool susfs_is_mnt_devname_ksu(struct path *path);
+extern bool susfs_is_mnt_devname_ksu(struct path *path);
 #ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
 extern bool susfs_is_log_enabled __read_mostly;
 #endif


### PR DESCRIPTION
Avoid throwing the expected external declaration errors on kernel/core_hook.c at line 63 while compiling kernel RKSU with SUSFS