### PR TITLE
kernel: ksud: add ksu_handle_execve_ksud

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -468,6 +468,36 @@ bool ksu_is_safe_mode()
 	return false;
 }
 
+/* 
+ * ksu_handle_execve_ksud, execve_ksud handler for non kprobe
+ * adapted from sys_execve_handler_pre 
+ * https://github.com/tiann/KernelSU/commit/2027ac3
+ */
+__maybe_unused int ksu_handle_execve_ksud(const char __user *filename_user,
+			const char __user *const __user *__argv)
+{
+	struct user_arg_ptr argv = { .ptr.native = __argv };
+	struct filename filename_in, *filename_p;
+	char path[32];
+
+	// return early if disabled.
+	if (!ksu_execveat_hook) {
+		return 0;
+	}
+
+	if (!filename_user)
+		return 0;
+
+	memset(path, 0, sizeof(path));
+	ksu_strncpy_from_user_nofault(path, filename_user, 32);
+
+	// this is because ksu_handle_execveat_ksud calls it filename->name
+	filename_in.name = path;
+	filename_p = &filename_in;
+    
+	return ksu_handle_execveat_ksud(AT_FDCWD, &filename_p, &argv, NULL, NULL);
+}
+
 #ifdef KSU_HOOK_WITH_KPROBES
 
 // https://elixir.bootlin.com/linux/v5.10.158/source/fs/exec.c#L1864


### PR DESCRIPTION
adapted from sys_execve_handler_pre()
upstream, https://github.com/tiann/KernelSU/commit/2027ac3

this completes the puzzle where all hooks are on syscalls

ksu_handle_execve_ksud
- sets argv to __argv, dunno what this is for, I just copied.
- creates dummy struct `filename_in` to store filename in `filename_in.name`
- strncpy filename to path, assign path to .name
- simply a shim for ksu_handle_execveat_ksud

usage: `ksu_handle_execve_ksud(filename, argv);` on sys_execve

tested on 4.14, 6.1

Tested-by: selfmusing <mirandamehek@gmail.com>
Tested-by: Adam W. Willis <return.of.octobot@gmail.com>
Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>