### PR TITLE
kernel: expose ksu_handle_execve_sucompat in susfs-v.1.5.5 branch

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -151,6 +151,33 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	return 0;
 }
 
+int ksu_handle_execve_sucompat(int *fd, const char __user **filename_user,
+			       void *__never_use_argv, void *__never_use_envp,
+			       int *__never_use_flags)
+{
+	const char su[] = SU_PATH;
+	char path[sizeof(su) + 1];
+
+	if (unlikely(!filename_user))
+		return 0;
+
+	memset(path, 0, sizeof(path));
+	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (likely(memcmp(path, su, sizeof(su))))
+		return 0;
+
+	if (!ksu_is_allow_uid(current_uid().val))
+		return 0;
+
+	pr_info("sys_execve su found\n");
+	*filename_user = ksud_user_path();
+
+	ksu_escape_to_root();
+
+	return 0;
+}
+
 int ksu_handle_devpts(struct inode *inode)
 {
 #ifndef KSU_HOOK_WITH_KPROBES
@@ -188,33 +215,6 @@ int ksu_handle_devpts(struct inode *inode)
 }
 
 #ifdef KSU_HOOK_WITH_KPROBES
-
-int ksu_handle_execve_sucompat(int *fd, const char __user **filename_user,
-			       void *__never_use_argv, void *__never_use_envp,
-			       int *__never_use_flags)
-{
-	const char su[] = SU_PATH;
-	char path[sizeof(su) + 1];
-
-	if (unlikely(!filename_user))
-		return 0;
-
-	memset(path, 0, sizeof(path));
-	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
-
-	if (likely(memcmp(path, su, sizeof(su))))
-		return 0;
-
-	if (!ksu_is_allow_uid(current_uid().val))
-		return 0;
-
-	pr_info("sys_execve su found\n");
-	*filename_user = ksud_user_path();
-
-	ksu_escape_to_root();
-
-	return 0;
-}
 
 static int faccessat_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {


### PR DESCRIPTION
Hi, it seems you pushed this fix to the main branch but not to the susfs-v1.5.5 branch where the issue was originally reported

Also fixed conflict, in original commit it's escape_to_root(); whereas here it's ksu_escape_to_root();

Fix ld.lld error

  MODPOST vmlinux.o
ld.lld: error: undefined symbol: ksu_handle_execve_sucompat
>>> referenced by exec.c
>>>               fs/exec.o:(SyS_execve) in archive built-in.o
>>> referenced by exec.c
>>>               fs/exec.o:(compat_SyS_execve) in archive built-in.o