### PR TITLE
kernel: Makefile: Remove stray backslash from path_umount grep regex

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -30,7 +30,7 @@ ccflags-y += -DKSU_VERSION=16
 endif
 
 # Do checks before compile
-ifeq ($(shell grep -q "int\s\+\path_umount" $(srctree)/fs/namespace.c; echo $$?),0)
+ifeq ($(shell grep -q "int\s\+path_umount" $(srctree)/fs/namespace.c; echo $$?),0)
 ccflags-y += -DKSU_HAS_PATH_UMOUNT
 endif
 


### PR DESCRIPTION
This fixes the following warning during kernel compilation:
grep: warning: stray \ before p