### PR TITLE
feat: avc: add a toggle to enable/disable avc log spoofing.

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -876,6 +876,17 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			return 0;
 		}
 #endif // #ifdef CONFIG_KSU_SUSFS_SUS_SU
+		if (arg2 == CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING) {
+			int error = 0;
+			if (arg3 != 0 && arg3 != 1) {
+				pr_err("susfs: CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING -> arg3 can only be 0 or 1\n");
+				return 0;
+			}
+			susfs_set_avc_log_spoofing(arg3);
+			if (copy_to_user((void __user*)arg5, &error, sizeof(error)))
+				pr_info("susfs: copy_to_user() failed\n");
+			return 0;
+		}
 	}
 #endif //#ifdef CONFIG_KSU_SUSFS
 

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -142,6 +142,7 @@ void ksu_apply_kernelsu_rules()
 #ifdef CONFIG_KSU_SUSFS
 	// Allow umount in zygote process without installing zygisk
 	ksu_allow(db, "zygote", "labeledfs", "filesystem", "unmount");
+	susfs_set_kernel_sid();
 	susfs_set_init_sid();
 	susfs_set_ksu_sid();
 	susfs_set_zygote_sid();

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -14,9 +14,11 @@
 #ifdef CONFIG_KSU_SUSFS
 #define KERNEL_INIT_DOMAIN "u:r:init:s0"
 #define KERNEL_ZYGOTE_DOMAIN "u:r:zygote:s0"
+#define KERNEL_KERNEL_DOMAIN "u:r:kernel:s0"
 u32 susfs_ksu_sid = 0;
 u32 susfs_init_sid = 0;
 u32 susfs_zygote_sid = 0;
+u32 susfs_kernel_sid = 0;
 #endif
 
 static int transive_to_domain(const char *domain)
@@ -234,6 +236,11 @@ void susfs_set_init_sid(void)
 
 bool susfs_is_current_init_domain(void) {
 	return unlikely(current_sid() == susfs_init_sid);
+}
+
+void susfs_set_kernel_sid(void)
+{
+	susfs_set_sid(KERNEL_KERNEL_DOMAIN, &susfs_kernel_sid);
 }
 #endif
 

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -39,7 +39,7 @@ perform_cleanup() {
 # Sets up or update KernelSU environment
 setup_kernelsu() {
     echo "[+] Setting up KernelSU..."
-    test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/rsuntk/KernelSU && echo "[+] Repository cloned."
+    test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/JackA1ltman/KernelSU && echo "[+] Repository cloned."
     cd "$GKI_ROOT/KernelSU"
     git stash && echo "[-] Stashed current changes."
     if [ "$(git status | grep -Po 'v\d+(\.\d+)*' | head -n1)" ]; then

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -39,7 +39,7 @@ perform_cleanup() {
 # Sets up or update KernelSU environment
 setup_kernelsu() {
     echo "[+] Setting up KernelSU..."
-    test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/JackA1ltman/KernelSU && echo "[+] Repository cloned."
+    test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/rsuntk/KernelSU && echo "[+] Repository cloned."
     cd "$GKI_ROOT/KernelSU"
     git stash && echo "[-] Stashed current changes."
     if [ "$(git status | grep -Po 'v\d+(\.\d+)*' | head -n1)" ]; then


### PR DESCRIPTION
The commit also includes a temporary fix to prevent avc log messages from being leaked by logd, addressing a potential security and privacy concern.
A new toggle has been added to the KernelSU susfs module, allowing users to enable or disable avc log spoofing. This provides greater flexibility and control over log behavior.

usage: ksu_susfs enable_avc_log_spoofing <0|1>

Commits:
https://gitlab.com/simonpunk/susfs4ksu/-/commit/38cfa59991744d03b1228be9470e7873aae3621b https://gitlab.com/simonpunk/susfs4ksu/-/commit/001057f637719fa9c7d2232067f127c21c00f82a