### PR TITLE
kernel: add wrapper for creds, refine disable_seccomp, revert some changes

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,7 +14,7 @@ kernelsu-objs += selinux/rules.o
 
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
-ccflags-y += -include $(srctree)/include/ksu_creds.h
+ccflags-y += -include $(srctree)/$(src)/include/ksu_creds.h
 
 obj-$(CONFIG_KSU) += kernelsu.o
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -11,8 +11,10 @@ kernelsu-objs += kernel_compat.o
 kernelsu-objs += selinux/selinux.o
 kernelsu-objs += selinux/sepolicy.o
 kernelsu-objs += selinux/rules.o
+
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
+ccflags-y += -include $(srctree)/include/ksu_creds.h
 
 obj-$(CONFIG_KSU) += kernelsu.o
 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -65,7 +65,7 @@ static inline bool is_allow_su()
 	return ksu_is_allow_uid(ksu_current_uid());
 }
 
-static inline bool is_unsupported_app_uid(uid_t uid)
+static inline bool is_unsupported_uid(uid_t uid)
 {
 #define LAST_APPLICATION_UID 19999
 	uid_t appid = uid % 100000;
@@ -526,13 +526,14 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 	return 0;
 }
 
-static bool is_non_appuid(kuid_t uid)
+static bool is_appuid(kuid_t uid)
 {
 #define PER_USER_RANGE 100000
 #define FIRST_APPLICATION_UID 10000
+#define LAST_APPLICATION_UID 19999
 
 	uid_t appid = uid.val % PER_USER_RANGE;
-	return appid < FIRST_APPLICATION_UID;
+	return appid >= FIRST_APPLICATION_UID && appid <= LAST_APPLICATION_UID;
 }
 
 static bool should_umount(struct path *path)
@@ -629,33 +630,29 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 		return 0;
 	}
 
-	if (is_non_appuid(new_uid)) {
-#ifdef CONFIG_KSU_DEBUG
-		pr_info("handle setuid ignore non application uid: %d\n", new_uid.val);
-#endif
+	if (!is_appuid(new_uid) || is_unsupported_uid(new_uid.val)) {
+		// pr_info("handle setuid ignore non application or isolated uid: %d\n", new_uid.val);
 		return 0;
-	}
-
-	// isolated process may be directly forked from zygote, always unmount
-	if (is_unsupported_app_uid(new_uid.val)) {
-#ifdef CONFIG_KSU_DEBUG
-		pr_info("handle umount for unsupported application uid: %d\n", new_uid.val);
-#endif
-		goto do_umount;
 	}
 
 	if (ksu_is_allow_uid(new_uid.val)) {
-#ifdef CONFIG_KSU_DEBUG
-		pr_info("handle setuid ignore allowed application: %d\n", new_uid.val);
-#endif
+		// pr_info("handle setuid ignore allowed application: %d\n", new_uid.val);
 		return 0;
 	}
 
-do_umount:
+	if (!ksu_uid_should_umount(new_uid.val)) {
+		return 0;
+	} else {
+#ifdef CONFIG_KSU_DEBUG
+		pr_info("uid: %d should not umount!\n", current_uid().val);
+#endif
+	}
+
 	// check old process's selinux context, if it is not zygote, ignore it!
 	// because some su apps may setuid to untrusted_app but they are in global mount namespace
 	// when we umount for such process, that is a disaster!
-	if (!is_zygote(old->security)) {
+	bool is_zygote_child = is_zygote(old->security);
+	if (!is_zygote_child) {
 		pr_info("handle umount ignore non zygote child: %d\n",
 			current->pid);
 		return 0;

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -131,7 +131,14 @@ static void disable_seccomp(void)
 
 #ifdef CONFIG_SECCOMP
 	current->seccomp.mode = 0;
+	// 5.9+ have filter_count and use seccomp_filter_release
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+	seccomp_filter_release(current->seccomp.filter);
+	atomic_set(&current->seccomp.filter_count, 0);
+#else
 	current->seccomp.filter = NULL;
+	put_seccomp_filter(current->seccomp.filter);
+#endif
 #else
 #endif
 }

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -130,16 +130,16 @@ static void disable_seccomp(void)
 #endif
 
 #ifdef CONFIG_SECCOMP
-	current->seccomp.mode = 0;
+	struct task_struct *tsk = get_current();
+	tsk->seccomp.mode = 0;
 	// 5.9+ have filter_count and use seccomp_filter_release
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
-	seccomp_filter_release(current->seccomp.filter);
-	atomic_set(&current->seccomp.filter_count, 0);
+	seccomp_filter_release(tsk);
+	atomic_set(&tsk->seccomp.filter_count, 0);
 #else
-	current->seccomp.filter = NULL;
-	put_seccomp_filter(current->seccomp.filter);
+	tsk->seccomp.filter = NULL;
+	put_seccomp_filter(tsk);
 #endif
-#else
 #endif
 }
 

--- a/kernel/include/ksu_creds.h
+++ b/kernel/include/ksu_creds.h
@@ -1,0 +1,39 @@
+/*
+ * KernelSU creds wrapper
+ *
+ * Provide a wrapper for a few credentials use (e.g current_uid().val),
+ * so it would be easier to maintain
+ * some older linux versions.
+ */
+
+#ifndef __KSU_H_CREDS
+#define __KSU_H_CREDS
+
+#include <linux/cred.h>
+#include <linux/version.h>
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0) &&	\
+	defined(CONFIG_UIDGID_STRICT_TYPE_CHECKS)) ||	\
+	LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+#define ksu_cred_uid(x)		((x)->uid.val)
+#define ksu_cred_suid(x)	((x)->suid.val)
+#define ksu_cred_euid(x)	((x)->euid.val)
+#define ksu_cred_fsuid(x)	((x)->fsuid.val)
+#define ksu_cred_gid(x)		((x)->gid.val)
+#define ksu_cred_fsgid(x)	((x)->fsgid.val)
+#define ksu_cred_sgid(x)	((x)->sgid.val)
+#define ksu_cred_egid(x)	((x)->egid.val)
+#define ksu_current_uid()	(current_uid().val)
+#else
+#define ksu_cred_uid(x)		((x)->uid)
+#define ksu_cred_suid(x)	((x)->suid)
+#define ksu_cred_euid(x)	((x)->euid)
+#define ksu_cred_fsuid(x)	((x)->fsuid)
+#define ksu_cred_gid(x)		((x)->gid)
+#define ksu_cred_fsgid(x)	((x)->fsgid)
+#define ksu_cred_sgid(x)	((x)->sgid)
+#define ksu_cred_egid(x)	((x)->egid)
+#define ksu_current_uid()	(current_uid())
+#endif
+
+#endif

--- a/kernel/manager.h
+++ b/kernel/manager.h
@@ -15,7 +15,7 @@ static inline bool ksu_is_manager_uid_valid()
 
 static inline bool is_manager()
 {
-	return unlikely(ksu_manager_uid == current_uid().val);
+	return unlikely(ksu_manager_uid == ksu_current_uid());
 }
 
 static inline uid_t ksu_get_manager_uid()

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -58,7 +58,7 @@ static inline bool __is_su_allowed(const void *ptr_to_check)
 	if (!ksu_sucompat_hook_state)
 		return false;
 #endif
-	if (likely(!ksu_is_allow_uid(current_uid().val)))
+	if (likely(!ksu_is_allow_uid(ksu_current_uid())))
 		return false;
 
 	if (unlikely(!ptr_to_check))
@@ -149,7 +149,7 @@ static int ksu_inline_handle_devpts(struct inode *inode)
 		return 0;
 	}
 
-	uid_t uid = current_uid().val;
+	uid_t uid = ksu_current_uid();
 	if (uid % 100000 < 10000) {
 		// not untrusted_app, ignore it
 		return 0;


### PR DESCRIPTION
1. Wrapper for creds:
* Some older kernel does not have {.val}, so, for nicer compatibility support and clean code,
make some wrapper for credential use.
* After this change, do not use current_uid().val, instead, use ksu_current_uid(). For more
info, check kernel/include/ksu_creds.h.

2. Refine disable_seccomp (need to add k6.11+ support)
https://github.com/tiann/KernelSU/pull/2708
https://github.com/tiann/KernelSU/issues/2706

3. Revert "Handle unmount for isolated process correctly"
Reason: https://github.com/tiann/KernelSU/pull/2696#issuecomment-3181866301

Co-authored-by: Wang Han <416810799@qq.com>