### PR TITLE
kernel: Remove unnecessary strip in CONFIG_KSU_MANUAL_HOOK

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -32,7 +32,7 @@ ccflags-y += -DKSU_VERSION=16
 endif
 
 # Checks hooks state
-ifeq ($(strip $(CONFIG_KSU_MANUAL_HOOK)),y)
+ifeq ($(CONFIG_KSU_MANUAL_HOOK), y)
 $(info -- KernelSU: CONFIG_KSU_MANUAL_HOOK)
 else
 $(info -- KernelSU: CONFIG_KSU_KPROBES_HOOK)


### PR DESCRIPTION
The 'strip' function is redundant when checking Kconfig variables, as values from CONFIG options (like CONFIG_KSU_MANUAL_HOOK) are already trimmed and do not contain leading/trailing whitespace.

Simplify the condition for better readability and maintainability:
  - Remove unnecessary $(strip ...)
  - Add consistent spacing around the comma

This change aligns with kernel Makefile conventions and improves code clarity without altering behavior.