### PR TITLE
kernel: pkg_observer: Add (half) older kernel compatibility support

### DIFF
--- a/kernel/pkg_observer.c
+++ b/kernel/pkg_observer.c
@@ -2,7 +2,7 @@
 #include <linux/module.h>
 #include <linux/fs.h>
 #include <linux/namei.h>
-#include <linux/fsnotify_backend.h>
+#include <linux/fsnotify.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/rculist.h>


### PR DESCRIPTION
* Pre Linux 5.9, handle_inode_event did not exist. This is was covered by handle_event.
* handle_event have a lot of changes, neither in arguments counts and arguments arrangements.
* Use fsnotify_add_mark_locked instead of fsnotify_add_inode_mark for kernel pre 4.12

NOTE: fsnotify_add_mark_locked is not tested! Report bugs if you found it!