### PR TITLE
kernel: Add __poll_t compat

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -89,6 +89,11 @@ ifeq ($(shell grep -q "inode_security_struct\s\+\*selinux_inode" $(srctree)/secu
 ccflags-y += -DKSU_OPTIONAL_SELINUX_INODE
 endif
 
+# Check if __poll_t is available
+ifeq ($(shell grep -q "__poll_t" $(srctree)/include/linux/poll.h; echo $$?),1)
+ccflags-y += -DKSU_NEED_POLL_T_DEF
+endif
+
 # Checks Samsung
 ifeq ($(shell grep -q "CONFIG_KDP_CRED" $(srctree)/kernel/cred.c; echo $$?),0)
 ccflags-y += -DSAMSUNG_UH_DRIVER_EXIST

--- a/kernel/file_wrapper.c
+++ b/kernel/file_wrapper.c
@@ -20,6 +20,10 @@
 
 #include "file_wrapper.h"
 
+#ifdef KSU_NEED_POLL_T_DEF
+typedef unsigned __bitwise __poll_t;
+#endif
+
 static loff_t mksu_wrapper_llseek(struct file *fp, loff_t off, int flags)
 {
 	struct ksu_file_wrapper *data = fp->private_data;


### PR DESCRIPTION
__poll_t was introduced in v4.16-rc1. This adds a Makefile header check to detect __poll_t and provide fallback definition for older kernels and those with backports.