### PR TITLE
manager: Update About page links

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/About.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/About.kt
@@ -73,8 +73,8 @@ fun AboutScreen(navigator: DestinationsNavigator) {
 
     val htmlString = stringResource(
         id = R.string.about_source_code,
-        "<b><a href=\"https://github.com/tiann/KernelSU\">GitHub</a></b>",
-        "<b><a href=\"https://t.me/KernelSU\">Telegram</a></b>"
+        "<b><a href=\"https://github.com/rsuntk/KernelSU\">GitHub</a></b>",
+        "<b><a href=\"https://t.me/rsukrnlsu\">Telegram</a></b>"
     )
     val result = extractLinks(htmlString)
 


### PR DESCRIPTION
Currently, the About page redirects users to the upstream repository and the official KernelSU Telegram channel.
This PR updates the GitHub and Telegram URLs to point to this fork and its corresponding support channel, ensuring users land on the pages relevant to this specific build.
*Note: If retaining the upstream links was a deliberate choice, feel free to disregard/close this PR.*