### PR TITLE
manager: make blur optional (alternative to removal)

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -85,6 +85,7 @@ class MainActivity : ComponentActivity() {
             val prefs = context.getSharedPreferences("settings", MODE_PRIVATE)
             var colorMode by remember { mutableIntStateOf(prefs.getInt("color_mode", 0)) }
             var keyColorInt by remember { mutableIntStateOf(prefs.getInt("key_color", 0)) }
+            var blurEnabled by remember { mutableStateOf(prefs.getBoolean("enable_blur", true)) }
             val keyColor = remember(keyColorInt) { if (keyColorInt == 0) null else Color(keyColorInt) }
 
             val darkMode = when (colorMode) {
@@ -112,6 +113,7 @@ class MainActivity : ComponentActivity() {
                     when (key) {
                         "color_mode" -> colorMode = prefs.getInt("color_mode", 0)
                         "key_color" -> keyColorInt = prefs.getInt("key_color", 0)
+                        "enable_blur" -> blurEnabled = prefs.getBoolean("enable_blur", true)
                     }
                 }
                 prefs.registerOnSharedPreferenceChangeListener(listener)
@@ -130,8 +132,9 @@ class MainActivity : ComponentActivity() {
                     navigator = navigator
                 )
 
-                Scaffold {
-                    DestinationsNavHost(
+                CompositionLocalProvider(me.weishu.kernelsu.ui.util.LocalBlurEnabled provides blurEnabled) {
+                    Scaffold {
+                        DestinationsNavHost(
                         modifier = Modifier,
                         navGraph = NavGraphs.root,
                         navController = navController,
@@ -167,8 +170,9 @@ class MainActivity : ComponentActivity() {
                                         animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing)
                                     )
                                 }
-                        }
-                    )
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/BottomBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/BottomBar.kt
@@ -22,7 +22,7 @@ import me.weishu.kernelsu.ui.LocalSelectedPage
 import me.weishu.kernelsu.ui.util.rootAvailable
 import top.yukonga.miuix.kmp.basic.NavigationBar
 import top.yukonga.miuix.kmp.basic.NavigationItem
-
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 @Composable
 fun BottomBar(
@@ -34,6 +34,7 @@ fun BottomBar(
 
     val page = LocalSelectedPage.current
     val handlePageChange = LocalHandlePageChange.current
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
 
     if (!fullFeatured) return
 
@@ -45,13 +46,16 @@ fun BottomBar(
     }
 
     NavigationBar(
-        modifier = Modifier
-            .hazeEffect(hazeState) {
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
                 style = hazeStyle
-                blurRadius = 30.dp
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
                 noiseFactor = 0f
-            },
-        color = Color.Transparent,
+            }
+        } else {
+            Modifier
+        },
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         items = item,
         selected = page,
         onClick = handlePageChange

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SuperSearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SuperSearchBar.kt
@@ -117,15 +117,16 @@ class SearchStatus(val label: String) {
             if (visible) 1f else 0f,
             animationSpec = tween(if (visible) 550 else 0, easing = FastOutSlowInEasing),
         )
+        val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
         Box(modifier = modifier) {
             Box(
                 modifier = Modifier
                     .matchParentSize()
                     .then(
-                        if (hazeState != null && hazeStyle != null) {
+                        if (hazeState != null && hazeStyle != null && blurEnabled) {
                             Modifier.hazeEffect(hazeState) {
                                 style = hazeStyle
-                                blurRadius = 30.dp
+                                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
                                 noiseFactor = 0f
                             }
                         } else {
@@ -163,6 +164,7 @@ fun SearchStatus.SearchBox(
 
     val offsetY = remember { mutableIntStateOf(0) }
     val boxHeight = remember { mutableStateOf(0.dp) }
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
 
     Box(
         modifier = Modifier
@@ -182,11 +184,17 @@ fun SearchStatus.SearchBox(
             .pointerInput(Unit) {
                 detectTapGestures { searchStatus.current = SearchStatus.Status.EXPANDING }
             }
-            .hazeEffect(hazeState) {
-                style = hazeStyle
-                blurRadius = 30.dp
-                noiseFactor = 0f
-            }
+            .then(
+                if (blurEnabled) {
+                    Modifier.hazeEffect(hazeState) {
+                        style = hazeStyle
+                        blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                        noiseFactor = 0f
+                    }
+                } else {
+                    Modifier.background(colorScheme.surface)
+                }
+            )
     ) {
         collapseBar(searchStatus, searchBarTopPadding, contentPadding)
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/About.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/About.kt
@@ -54,6 +54,7 @@ import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.TopAppBar
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.extra.SuperArrow
 import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.useful.Back
@@ -78,15 +79,20 @@ fun AboutScreen(navigator: DestinationsNavigator) {
     )
     val result = extractLinks(htmlString)
 
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     Scaffold(
         topBar = {
             TopAppBar(
-                modifier = Modifier.hazeEffect(hazeState) {
-                    style = hazeStyle
-                    blurRadius = 30.dp
-                    noiseFactor = 0f
+                modifier = if (blurEnabled) {
+                    Modifier.hazeEffect(hazeState) {
+                        style = hazeStyle
+                        blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                        noiseFactor = 0f
+                    }
+                } else {
+                    Modifier
                 },
-                color = Color.Transparent,
+                color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
                 title = stringResource(R.string.about),
                 navigationIcon = {
                     IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
@@ -95,6 +95,7 @@ import top.yukonga.miuix.kmp.extra.SuperSwitch
 import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.useful.Back
 import top.yukonga.miuix.kmp.icon.icons.useful.ImmersionMore
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
@@ -550,13 +551,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     TopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
-        color = Color.Transparent,
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = stringResource(R.string.profile),
         navigationIcon = {
             IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ExecuteModuleAction.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ExecuteModuleAction.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
@@ -59,6 +60,7 @@ import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.useful.Back
 import top.yukonga.miuix.kmp.icon.icons.useful.Save
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
 import java.io.File
@@ -175,12 +177,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     SmallTopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = stringResource(R.string.action),
         navigationIcon = {
             IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
@@ -257,13 +257,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     TopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
-        color = Color.Transparent,
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = stringResource(R.string.app_name),
         actions = {
             RebootListPopup(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Install.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Install.kt
@@ -84,6 +84,7 @@ import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.useful.Back
 import top.yukonga.miuix.kmp.icon.icons.useful.Edit
 import top.yukonga.miuix.kmp.icon.icons.useful.Move
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
@@ -419,13 +420,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     TopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
-        color = Color.Transparent,
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = stringResource(R.string.install),
         navigationIcon = {
             IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
@@ -128,6 +128,7 @@ import top.yukonga.miuix.kmp.icon.icons.useful.Back
 import top.yukonga.miuix.kmp.icon.icons.useful.ImmersionMore
 import top.yukonga.miuix.kmp.icon.icons.useful.NavigatorSwitch
 import top.yukonga.miuix.kmp.icon.icons.useful.Save
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.PressFeedbackType
 import top.yukonga.miuix.kmp.utils.overScrollVertical
@@ -1022,15 +1023,20 @@ fun ModuleRepoDetailScreen(
         tint = HazeTint(colorScheme.surface.copy(0.8f))
     )
 
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     Scaffold(
         topBar = {
             TopAppBar(
-                modifier = Modifier.hazeEffect(hazeState) {
-                    style = hazeStyle
-                    blurRadius = 30.dp
-                    noiseFactor = 0f
+                modifier = if (blurEnabled) {
+                    Modifier.hazeEffect(hazeState) {
+                        style = hazeStyle
+                        blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                        noiseFactor = 0f
+                    }
+                } else {
+                    Modifier
                 },
-                color = Color.Transparent,
+                color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
                 title = module.moduleName,
                 scrollBehavior = scrollBehavior,
                 navigationIcon = {
@@ -1124,11 +1130,13 @@ fun ModuleRepoDetailScreen(
             }
             Column(
                 modifier = Modifier
-                    .hazeEffect(hazeState) {
-                        style = hazeStyle
-                        blurRadius = 30.dp
-                        noiseFactor = 0f
-                    }
+                    .then(if (blurEnabled) {
+                        Modifier.hazeEffect(hazeState) {
+                            style = hazeStyle
+                            blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                            noiseFactor = 0f
+                        }
+                    } else Modifier.background(MiuixTheme.colorScheme.surface))
                     .zIndex(1f)
                     .padding(
                         top = innerPadding.calculateTopPadding() + dynamicTopPadding,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Settings.kt
@@ -76,6 +76,7 @@ import top.yukonga.miuix.kmp.basic.TopAppBar
 import top.yukonga.miuix.kmp.extra.SuperArrow
 import top.yukonga.miuix.kmp.extra.SuperDropdown
 import top.yukonga.miuix.kmp.extra.SuperSwitch
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
@@ -97,15 +98,20 @@ fun SettingPager(
         tint = HazeTint(colorScheme.surface.copy(0.8f))
     )
 
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     Scaffold(
         topBar = {
             TopAppBar(
-                modifier = Modifier.hazeEffect(hazeState) {
-                    style = hazeStyle
-                    blurRadius = 30.dp
-                    noiseFactor = 0f
+                modifier = if (blurEnabled) {
+                    Modifier.hazeEffect(hazeState) {
+                        style = hazeStyle
+                        blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                        noiseFactor = 0f
+                    }
+                } else {
+                    Modifier
                 },
-                color = Color.Transparent,
+                color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
                 title = stringResource(R.string.settings),
                 scrollBehavior = scrollBehavior
             )
@@ -220,6 +226,27 @@ fun SettingPager(
                         onSelectedIndexChange = { index ->
                             prefs.edit { putInt("color_mode", index) }
                             themeMode = index
+                        }
+                    )
+
+                    var enableBlur by rememberSaveable {
+                        mutableStateOf(prefs.getBoolean("enable_blur", true))
+                    }
+                    SuperSwitch(
+                        title = stringResource(id = R.string.settings_blur),
+                        summary = stringResource(id = R.string.settings_blur_summary),
+                        leftAction = {
+                            Icon(
+                                Icons.Rounded.Palette,
+                                modifier = Modifier.padding(end = 16.dp),
+                                contentDescription = stringResource(id = R.string.settings_blur),
+                                tint = colorScheme.onBackground
+                            )
+                        },
+                        checked = enableBlur,
+                        onCheckedChange = {
+                            prefs.edit { putBoolean("enable_blur", it) }
+                            enableBlur = it
                         }
                     )
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Template.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Template.kt
@@ -426,13 +426,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     TopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
-        color = Color.Transparent,
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = stringResource(R.string.settings_profile_template),
         navigationIcon = {
             IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/TemplateEditor.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/TemplateEditor.kt
@@ -61,6 +61,7 @@ import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.useful.Back
 import top.yukonga.miuix.kmp.icon.icons.useful.Confirm
 import top.yukonga.miuix.kmp.icon.icons.useful.Delete
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
@@ -310,13 +311,18 @@ private fun TopBar(
     hazeState: HazeState,
     hazeStyle: HazeStyle,
 ) {
+    val blurEnabled = me.weishu.kernelsu.ui.util.LocalBlurEnabled.current
     TopAppBar(
-        modifier = Modifier.hazeEffect(hazeState) {
-            style = hazeStyle
-            blurRadius = 30.dp
-            noiseFactor = 0f
+        modifier = if (blurEnabled) {
+            Modifier.hazeEffect(hazeState) {
+                style = hazeStyle
+                blurRadius = me.weishu.kernelsu.ui.util.blurRadius(blurEnabled)
+                noiseFactor = 0f
+            }
+        } else {
+            Modifier
         },
-        color = Color.Transparent,
+        color = if (blurEnabled) Color.Transparent else MiuixTheme.colorScheme.surface,
         title = title,
         navigationIcon = {
             IconButton(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/BlurManager.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/BlurManager.kt
@@ -1,0 +1,11 @@
+package me.weishu.kernelsu.ui.util
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+val LocalBlurEnabled = compositionLocalOf { true }
+
+fun blurRadius(enabled: Boolean): Dp {
+    return if (enabled) 30.dp else 0.dp
+}

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -177,6 +177,8 @@
     <string name="settings_theme_mode_monet_system">Monet (Follow system)</string>
     <string name="settings_theme_mode_monet_light">Monet (Light)</string>
     <string name="settings_theme_mode_monet_dark">Monet (Dark)</string>
+    <string name="settings_blur">Realtime Blur</string>
+    <string name="settings_blur_summary">Enable real-time Gaussian blur in the UI.</string>
     <string name="settings_key_color">Key color</string>
     <string name="settings_key_color_summary">Customize accent when using Monet.</string>
     <string name="settings_key_color_default">Default</string>


### PR DESCRIPTION
Shi is laggy on one of my legacy devices🥀 (ugg).

I noticed there was a plan to completely remove the UI blur due to performance overhead on some devices. Instead of nuking the feature, this PR implements a **"Realtime Blur" toggle** in Settings.
<img width="1080" height="2400" alt="Screenshot_20251231-004456_KernelSU" src="https://github.com/user-attachments/assets/042e5a07-13f9-4dbf-8d73-eca6d169151d" />

- **On:** Original glass look.
- **Off:** Solid surface background.

Still learning Kotlin btw, so the implementation might not be perfect. However, if the plan is indeed to remove it completely, feel free to ignore or close this PR.